### PR TITLE
Size Regression Mitigation - Part 2

### DIFF
--- a/lib/Transforms/IPO/SALSSACodeGen.cpp
+++ b/lib/Transforms/IPO/SALSSACodeGen.cpp
@@ -253,7 +253,6 @@ static void CodeGen(BlockListType &Blocks1, BlockListType &Blocks2,
                 NewBB = BasicBlock::Create(MergedFunc->getContext(), BBName,
                                            MergedFunc);
                 ChainBlocks(LastMergedBB, NewBB, FuncId);
-                BlocksFX[NewBB] = BB;
                 // errs() << "Splitting last merged " << LastMergedBB->getName()
                 // << " into " << NewBB->getName() << "\n";
               }
@@ -561,8 +560,8 @@ bool FunctionMerger::SALSSACodeGen<BlockListType>::generate(
 
     if (IV1 && IV2) {
       // if both IV1 and IV2 are non-merged values
-      if (BlocksF2.find(IV1->getParent()) == BlocksF2.end() &&
-          BlocksF1.find(IV2->getParent()) == BlocksF1.end()) {
+      if (BlocksF1.find(IV1->getParent()) == BlocksF1.end() &&
+          BlocksF2.find(IV2->getParent()) == BlocksF2.end()) {
         CoalescingCandidates[IV1][IV2]++;
         CoalescingCandidates[IV2][IV1]++;
       }

--- a/test/Transforms/NextFM/CodeGen/libjpeg/5_multiple-func-merging_CodeGen.ll
+++ b/test/Transforms/NextFM/CodeGen/libjpeg/5_multiple-func-merging_CodeGen.ll
@@ -4,7 +4,6 @@
 
 ; RUN: %opt -S --passes="multiple-func-merging" -func-merging-explore 2 -o /dev/null -pass-remarks-output=- -pass-remarks-filter=multiple-func-merging < %s | FileCheck %s
 ; CHECK-NOT: --- !Missed
-; XFAIL: *
 
 ; ModuleID = '../bench-play/libjpeg.bc'
 source_filename = "llvm-link"

--- a/test/Transforms/NextFM/CodeGen/libjpeg/build_ycc_rgb_table.43_build_ycc_rgb_table.ll
+++ b/test/Transforms/NextFM/CodeGen/libjpeg/build_ycc_rgb_table.43_build_ycc_rgb_table.ll
@@ -7,7 +7,6 @@
 ; RUN: %strip %t.mfm.o
 ; RUN: %strip %t.fm.o
 ; RUN: [[ $(stat -c%%s %t.mfm.o) -le $(stat -c%%s %t.fm.o) ]]
-; XFAIL: *
 
 ; ModuleID = '../benchmarks/mibench/consumer/jpeg/cjpeg.bc'
 source_filename = "llvm-link"

--- a/test/Transforms/NextFM/CodeGen/libjpeg/get_interlaced_row_get_8bit_row.267.ll
+++ b/test/Transforms/NextFM/CodeGen/libjpeg/get_interlaced_row_get_8bit_row.267.ll
@@ -6,7 +6,7 @@
 ; RUN: %llc --filetype=obj %t.fm.ll -o %t.fm.o
 ; RUN: %strip %t.mfm.o
 ; RUN: %strip %t.fm.o
-; RUN: [[ $(stat -c%%s %t.mfm.o) -le $(stat -c%%s %t.fm.o) ]]
+; RUN: test $(stat -c%%s %t.mfm.o) -le $(stat -c%%s %t.fm.o)
 ; XFAIL: *
 
 ; ModuleID = '../benchmarks/mibench/consumer/jpeg/cjpeg.bc'

--- a/test/Transforms/NextFM/CodeGen/libjpeg/get_interlaced_row_get_8bit_row.267.reduced.ll
+++ b/test/Transforms/NextFM/CodeGen/libjpeg/get_interlaced_row_get_8bit_row.267.reduced.ll
@@ -1,0 +1,64 @@
+; RUN: %opt -S --passes="multiple-func-merging" --multiple-func-merging-only=get_interlaced_row --multiple-func-merging-only=get_8bit_row.267 -o %t.mfm.ll %s
+; RUN: %opt -S --passes="func-merging" --func-merging-only=get_interlaced_row --func-merging-only=get_8bit_row.267 -o %t.fm.ll %s
+; RUN: %llc --filetype=obj %t.mfm.ll -o %t.mfm.o
+; RUN: %llc --filetype=obj %t.fm.ll -o %t.fm.o
+; RUN: %strip %t.mfm.o
+; RUN: %strip %t.fm.o
+; RUN: test $(stat -c%%s %t.mfm.o) -le $(stat -c%%s %t.fm.o)
+
+source_filename = "llvm-link"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.jpeg_compress_struct = type { %struct.jpeg_error_mgr*, %struct.jpeg_memory_mgr*, %struct.jpeg_progress_mgr*, i32, i32, %struct.jpeg_destination_mgr*, i32, i32, i32, i32, double, i32, i32, i32, %struct.jpeg_component_info*, [4 x %struct.JQUANT_TBL*], [4 x %struct.JHUFF_TBL*], [4 x %struct.JHUFF_TBL*], [16 x i8], [16 x i8], [16 x i8], i32, %struct.jpeg_scan_info*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i8, i16, i16, i32, i32, i32, i32, i32, i32, i32, [4 x %struct.jpeg_component_info*], i32, i32, i32, [10 x i32], i32, i32, i32, i32, %struct.jpeg_comp_master*, %struct.jpeg_c_main_controller*, %struct.jpeg_c_prep_controller*, %struct.jpeg_c_coef_controller*, %struct.jpeg_marker_writer*, %struct.jpeg_color_converter*, %struct.jpeg_downsampler*, %struct.jpeg_forward_dct*, %struct.jpeg_entropy_encoder* }
+%struct.jpeg_error_mgr = type { void (%struct.jpeg_common_struct*)*, void (%struct.jpeg_common_struct*, i32)*, void (%struct.jpeg_common_struct*)*, void (%struct.jpeg_common_struct*, i8*)*, void (%struct.jpeg_common_struct*)*, i32, %union.anon, i32, i64, i8**, i32, i8**, i32, i32 }
+%struct.jpeg_common_struct = type { %struct.jpeg_error_mgr*, %struct.jpeg_memory_mgr*, %struct.jpeg_progress_mgr*, i32, i32 }
+%union.anon = type { [8 x i32], [48 x i8] }
+%struct.jpeg_memory_mgr = type { i8* (%struct.jpeg_common_struct*, i32, i64)*, i8* (%struct.jpeg_common_struct*, i32, i64)*, i8** (%struct.jpeg_common_struct*, i32, i32, i32)*, [64 x i16]** (%struct.jpeg_common_struct*, i32, i32, i32)*, %struct.jvirt_sarray_control* (%struct.jpeg_common_struct*, i32, i32, i32, i32, i32)*, %struct.jvirt_barray_control* (%struct.jpeg_common_struct*, i32, i32, i32, i32, i32)*, {}*, i8** (%struct.jpeg_common_struct*, %struct.jvirt_sarray_control*, i32, i32, i32)*, [64 x i16]** (%struct.jpeg_common_struct*, %struct.jvirt_barray_control*, i32, i32, i32)*, void (%struct.jpeg_common_struct*, i32)*, {}*, i64 }
+%struct.jvirt_sarray_control = type { i8**, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, %struct.jvirt_sarray_control*, %struct.backing_store_struct }
+%struct.backing_store_struct = type { void (%struct.jpeg_common_struct.775*, %struct.backing_store_struct*, i8*, i64, i64)*, void (%struct.jpeg_common_struct.775*, %struct.backing_store_struct*, i8*, i64, i64)*, void (%struct.jpeg_common_struct.775*, %struct.backing_store_struct*)*, %struct._IO_FILE*, [64 x i8] }
+%struct.jpeg_common_struct.775 = type { %struct.jpeg_error_mgr.766*, %struct.jpeg_memory_mgr.773*, %struct.jpeg_progress_mgr*, i32, i32 }
+%struct.jpeg_error_mgr.766 = type { {}*, void (%struct.jpeg_common_struct.775*, i32)*, {}*, void (%struct.jpeg_common_struct.775*, i8*)*, {}*, i32, %union.anon, i32, i64, i8**, i32, i8**, i32, i32 }
+%struct.jpeg_memory_mgr.773 = type { i8* (%struct.jpeg_common_struct.775*, i32, i64)*, i8* (%struct.jpeg_common_struct.775*, i32, i64)*, i8** (%struct.jpeg_common_struct.775*, i32, i32, i32)*, [64 x i16]** (%struct.jpeg_common_struct.775*, i32, i32, i32)*, %struct.jvirt_sarray_control* (%struct.jpeg_common_struct.775*, i32, i32, i32, i32, i32)*, %struct.jvirt_barray_control* (%struct.jpeg_common_struct.775*, i32, i32, i32, i32, i32)*, {}*, i8** (%struct.jpeg_common_struct.775*, %struct.jvirt_sarray_control*, i32, i32, i32)*, [64 x i16]** (%struct.jpeg_common_struct.775*, %struct.jvirt_barray_control*, i32, i32, i32)*, void (%struct.jpeg_common_struct.775*, i32)*, {}*, i64 }
+%struct.jvirt_barray_control = type { [64 x i16]**, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, %struct.jvirt_barray_control*, %struct.backing_store_struct }
+%struct._IO_FILE = type { i32, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, i8*, %struct._IO_marker*, %struct._IO_FILE*, i32, i32, i64, i16, i8, [1 x i8], i8*, i64, %struct._IO_codecvt*, %struct._IO_wide_data*, %struct._IO_FILE*, i8*, i64, i32, [20 x i8] }
+%struct._IO_marker = type opaque
+%struct._IO_codecvt = type opaque
+%struct._IO_wide_data = type opaque
+%struct.jpeg_progress_mgr = type { {}*, i64, i64, i32, i32 }
+%struct.jpeg_destination_mgr = type { i8*, i64, void (%struct.jpeg_compress_struct*)*, i32 (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)* }
+%struct.jpeg_component_info = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, %struct.JQUANT_TBL*, i8* }
+%struct.JQUANT_TBL = type { [64 x i16], i32 }
+%struct.JHUFF_TBL = type { [17 x i8], [256 x i8], i32 }
+%struct.jpeg_scan_info = type { i32, [4 x i32], i32, i32, i32, i32 }
+%struct.jpeg_comp_master = type { void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)*, i32, i32 }
+%struct.jpeg_c_main_controller = type { void (%struct.jpeg_compress_struct*, i32)*, void (%struct.jpeg_compress_struct*, i8**, i32*, i32)* }
+%struct.jpeg_c_prep_controller = type { void (%struct.jpeg_compress_struct*, i32)*, void (%struct.jpeg_compress_struct*, i8**, i32*, i32, i8***, i32*, i32)* }
+%struct.jpeg_c_coef_controller = type { void (%struct.jpeg_compress_struct*, i32)*, i32 (%struct.jpeg_compress_struct*, i8***)* }
+%struct.jpeg_marker_writer = type { void (%struct.jpeg_compress_struct*, i32, i8*, i32)*, void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*)* }
+%struct.jpeg_color_converter = type { void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*, i8**, i8***, i32, i32)* }
+%struct.jpeg_downsampler = type { void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*, i8***, i32, i8***, i32)*, i32 }
+%struct.jpeg_forward_dct = type { void (%struct.jpeg_compress_struct*)*, void (%struct.jpeg_compress_struct*, %struct.jpeg_component_info*, i8**, [64 x i16]*, i32, i32, i32)* }
+%struct.jpeg_entropy_encoder = type { void (%struct.jpeg_compress_struct*, i32)*, i32 (%struct.jpeg_compress_struct*, [64 x i16]**)*, void (%struct.jpeg_compress_struct*)* }
+%struct.gif_source_struct = type { %struct.cjpeg_source_struct, %struct.jpeg_compress_struct*, i8**, [260 x i8], i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16*, i8*, i8*, i8*, i32, %struct.jvirt_sarray_control*, i32, i32, i32, i32 }
+%struct.cjpeg_source_struct = type { void (%struct.jpeg_compress_struct*, %struct.cjpeg_source_struct*)*, i32 (%struct.jpeg_compress_struct*, %struct.cjpeg_source_struct*)*, void (%struct.jpeg_compress_struct*, %struct.cjpeg_source_struct*)*, %struct._IO_FILE*, i8**, i32 }
+%struct._bmp_source_struct = type { %struct.cjpeg_source_struct, %struct.jpeg_compress_struct*, i8**, %struct.jvirt_sarray_control*, i32, i32, i32 }
+
+define hidden i32 @get_interlaced_row() {
+  %1 = load %struct.jpeg_compress_struct*, %struct.jpeg_compress_struct** undef, align 8
+  %2 = getelementptr inbounds %struct.jpeg_compress_struct, %struct.jpeg_compress_struct* %1, i32 0, i32 1
+  %3 = load i8** (%struct.jpeg_common_struct*, %struct.jvirt_sarray_control*, i32, i32, i32)*, i8** (%struct.jpeg_common_struct*, %struct.jvirt_sarray_control*, i32, i32, i32)** undef, align 8
+  %4 = getelementptr inbounds %struct.gif_source_struct, %struct.gif_source_struct* undef, i32 0, i32 22
+  %5 = load %struct.jvirt_sarray_control*, %struct.jvirt_sarray_control** %4, align 8
+  %6 = call i8** %3(%struct.jpeg_common_struct* undef, %struct.jvirt_sarray_control* %5, i32 undef, i32 1, i32 0)
+  store i8** %6, i8*** undef, align 8
+  ret i32 undef
+}
+
+define hidden i32 @get_8bit_row.267() {
+  %1 = getelementptr inbounds %struct.jpeg_compress_struct, %struct.jpeg_compress_struct* undef, i32 0, i32 1
+  %2 = load %struct.jpeg_memory_mgr*, %struct.jpeg_memory_mgr** %1, align 8
+  %3 = getelementptr inbounds %struct._bmp_source_struct, %struct._bmp_source_struct* undef, i32 0, i32 3
+  %4 = load %struct.jvirt_sarray_control*, %struct.jvirt_sarray_control** %3, align 8
+  ret i32 undef
+}

--- a/test/Transforms/NextFM/CodeGen/libjpeg/get_sof_get_sos.ll
+++ b/test/Transforms/NextFM/CodeGen/libjpeg/get_sof_get_sos.ll
@@ -7,7 +7,6 @@
 ; RUN: %strip %t.mfm.o
 ; RUN: %strip %t.fm.o
 ; RUN: [[ $(stat -c%%s %t.mfm.o) -le $(stat -c%%s %t.fm.o) ]]
-; XFAIL: *
 
 ; ModuleID = '../benchmarks/mibench/consumer/jpeg/cjpeg.bc'
 source_filename = "llvm-link"


### PR DESCRIPTION
- Collect `CoalescingCandidates` in `mergeOperandValues`.
- Remove `BlocksFX[NewBB] = BB;` in splitted BB chaining because
BlocksFX is actually a map from merged BB to source BB. This wrong entry
prevents collecting `CoalescingCandidates` because non-merged BB was
treated as merged.
- Fix wrong `CoalescingCandidates` collecting logic in SoTA. `BlocksF1`
and `BlocksF2` were swapped and all BB were treated as un-merged...